### PR TITLE
Fix bug when writing large outputs

### DIFF
--- a/src/Server/Transport/StdioServerTransport.php
+++ b/src/Server/Transport/StdioServerTransport.php
@@ -333,6 +333,7 @@ class StdioServerTransport implements Transport {
             // Handle partial writes by re-buffering the unwritten part
             if ($written < strlen($data)) {
                 $this->writeBuffer = [substr($data, $written), ...$this->writeBuffer];
+            } else {
                 break;
             }
         }


### PR DESCRIPTION
It should not break when not all data was written, but continue. Now it's doing the opposite, leaving the Claude client wait forever.