### PR TITLE
Fix Tool.php failing due to type mismatch for tools with annotations

### DIFF
--- a/src/Types/Tool.php
+++ b/src/Types/Tool.php
@@ -42,11 +42,19 @@ class Tool implements McpModel {
     public static function fromArray(array $data): self {
         $name = $data['name'] ?? '';
         $description = $data['description'] ?? null;
-        $annotations = $data['annotations'] ?? null;
+        $annotationsData = $data['annotations'] ?? null;
         $inputSchemaData = $data['inputSchema'] ?? [];
         unset($data['name'], $data['description'], $data['inputSchema'], $data['annotations']);
 
         $inputSchema = ToolInputSchema::fromArray($inputSchemaData);
+
+        $annotations = null;
+		// Properly cast annotations to ToolAnnotations object.
+        if ($annotationsData !== null && is_array($annotationsData)) {
+            $annotations = ToolAnnotations::fromArray($annotationsData);
+        } elseif ($annotationsData instanceof ToolAnnotations) {
+            $annotations = $annotationsData;
+        }
 
         $obj = new self($name, $inputSchema, $description, $annotations);
 


### PR DESCRIPTION
When the server responds with tools containing annotations, the call fails because Tool.php requires tool annotations to be of type ToolAnnotations (line 39) but gets array

> Fatal error: Uncaught TypeError: Mcp\Types\Tool::__construct(): Argument #4 ($annotations) must be of type ?Mcp\Types\ToolAnnotations, array given, called in /var/www/html/wp-content/plugins/phpagent/vendor/logiscape/mcp-sdk-php/src/Types/Tool.php on line 51 and defined in /var/www/html/wp-content/plugins/phpagent/vendor/logiscape/mcp-sdk-php/src/Types/Tool.php:35