### PR TITLE
Remove duplicate class declaration

### DIFF
--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -336,14 +336,3 @@ class Server {
         return $this->session->clientSupportsFeature($feature);
     }
 }
-
-/**
- * NotificationOptions class to specify which capabilities are changed via notifications.
- */
-class NotificationOptions {
-    public function __construct(
-        public bool $promptsChanged = false,
-        public bool $resourcesChanged = false,
-        public bool $toolsChanged = false,
-    ) {}
-}


### PR DESCRIPTION
There should only be 1 class definition per file.

This class is already defined in `NotificationOptions.php`.