### PR TITLE
fix: unmatched }

### DIFF
--- a/src/Types/CompleteResult.php
+++ b/src/Types/CompleteResult.php
@@ -75,4 +75,3 @@ class CompleteResult extends Result {
         $this->completion->validate();
     }
 }
-}


### PR DESCRIPTION
This pull request includes a minor change to the `CompleteResult` class in `src/Types/CompleteResult.php`. It removes an unnecessary closing brace, likely left over from a previous edit.