### PR TITLE
Fix progress notification parameters

### DIFF
--- a/src/Shared/BaseSession.php
+++ b/src/Shared/BaseSession.php
@@ -220,11 +220,7 @@ abstract class BaseSession {
         $jsonRpcNotification = new JSONRPCNotification(
             jsonrpc: '2.0',
             method: $progressNotification->method,
-            params: [
-                'progressToken' => $progressToken,
-                'progress' => $progress,
-                'total' => $total
-            ]
+            params: $progressNotification->params
         );
 
         $jsonRpcMessage = new JsonRpcMessage($jsonRpcNotification);


### PR DESCRIPTION
## Summary
- use the `ProgressNotification` params object when building JSONRPC notifications

## Testing
- `php -l src/Shared/BaseSession.php` *(fails: `php` not installed)*