### PR TITLE
Support OAuth resource metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,14 @@ The HTTP server transport includes optional OAuth 2.1 support. Enable it by pass
 $transport = new HttpServerTransport([
     'auth_enabled' => true,
     'authorization_servers' => ['https://auth.example.com'],
+    'resource' => 'https://example.com/api',
     'token_validator' => new Mcp\Server\Auth\JwtTokenValidator('shared-secret')
 ]);
 ```
 
 When enabled, requests must include a `Bearer` access token in the `Authorization` header. Invalid or missing tokens receive a `401` response with a `WWW-Authenticate` header pointing to `/.well-known/oauth-protected-resource`.
+The metadata at this path describes the protected resource using the `resource` and `authorization_servers` options.
+Clients can retrieve it with a simple `GET` request to the path configured by `resource_metadata_path`.
 
 ## Documentation
 

--- a/src/Server/Transport/Http/Config.php
+++ b/src/Server/Transport/Http/Config.php
@@ -51,6 +51,7 @@ class Config
         'server_header' => 'MCP-PHP-Server/1.0', // Server identification
         'auth_enabled' => false,          // OAuth disabled by default
         'authorization_servers' => [],    // Authorization server metadata
+        'resource' => null,               // Protected resource identifier
         'resource_metadata_path' => '/.well-known/oauth-protected-resource',
         'token_validator' => null,        // Instance of TokenValidatorInterface
     ];
@@ -122,6 +123,15 @@ class Config
     {
         $servers = $this->options['authorization_servers'] ?? [];
         return is_array($servers) ? $servers : [];
+    }
+
+    /**
+     * Get the identifier for this protected resource.
+     */
+    public function getResource(): ?string
+    {
+        $resource = $this->options['resource'] ?? null;
+        return $resource !== null ? (string)$resource : null;
     }
 
     /**


### PR DESCRIPTION
## Summary
- expose `resource` option in `Http\Config`
- add `HttpServerTransport::getProtectedResourceMetadata()`
- serve metadata at the configured endpoint
- include `WWW-Authenticate` header when auth fails
- document new option in README

## Testing
- `php -l src/Server/Transport/HttpServerTransport.php` *(fails: `php` not installed)*
- `composer --version` *(fails: `composer` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847f13b0d6c832fb05503df8d54c605