### PR TITLE
Add claim validation in JwtTokenValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,12 @@ $transport = new HttpServerTransport([
     'auth_enabled' => true,
     'authorization_servers' => ['https://auth.example.com'],
     'resource' => 'https://example.com/api',
-    'token_validator' => new Mcp\Server\Auth\JwtTokenValidator('shared-secret')
+    'token_validator' => new Mcp\Server\Auth\JwtTokenValidator(
+        'shared-secret',
+        'HS256',
+        'https://auth.example.com',
+        'https://example.com/api'
+    )
 ]);
 ```
 


### PR DESCRIPTION
## Summary
- support claim validation for `exp`, `nbf`, `iat`, `iss` and `aud`
- allow passing expected issuer and audience to the validator
- document new parameters in README

## Testing
- `php -l src/Server/Auth/JwtTokenValidator.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848dab57068832f81bb6160c591d732