### PR TITLE
Make ToolInputProperties iterable by implementing IteratorAggregate

### DIFF
--- a/src/Types/ToolInputProperties.php
+++ b/src/Types/ToolInputProperties.php
@@ -35,7 +35,7 @@ namespace Mcp\Types;
  *
  * We allow arbitrary fields (keys = string, values = object).
  */
-class ToolInputProperties implements McpModel {
+class ToolInputProperties implements McpModel, \IteratorAggregate {
     use ExtraFieldsTrait;
 
     public static function fromArray(array $data): self {
@@ -55,5 +55,9 @@ class ToolInputProperties implements McpModel {
 
     public function jsonSerialize(): mixed {
         return empty($this->extraFields) ? new \stdClass() : $this->extraFields;
+    }
+
+    public function getIterator(): \Traversable {
+        return new \ArrayIterator($this->extraFields);
     }
 }


### PR DESCRIPTION
### Summary

This PR updates the `ToolInputProperties` class to implement the `IteratorAggregate` interface, enabling instances to be iterated over with `foreach` loops.

### Examples

```php
$props = ToolInputProperties::fromArray(
    [
        'name' => 'test',
        'description' => 'test description',
    ]
);

foreach ($props as $key => $value) {
    echo $key, '=', $value, PHP_EOL;
}
// Outputs:
// name=test
// description=test description
```
