### PR TITLE
Allow empty value for completion argument

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "logiscape/mcp-sdk-php",
+    "name": "chriskapp/mcp-sdk-php",
     "description": "Model Context Protocol SDK for PHP",
     "type": "library",
 	"license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "chriskapp/mcp-sdk-php",
+    "name": "logiscape/mcp-sdk-php",
     "description": "Model Context Protocol SDK for PHP",
     "type": "library",
 	"license": "MIT",

--- a/src/Types/CompletionArgument.php
+++ b/src/Types/CompletionArgument.php
@@ -47,9 +47,6 @@ class CompletionArgument implements McpModel {
         if (empty($this->name)) {
             throw new \InvalidArgumentException('Completion argument name cannot be empty');
         }
-        if (empty($this->value)) {
-            throw new \InvalidArgumentException('Completion argument value cannot be empty');
-        }
     }
 
     public function jsonSerialize(): mixed {


### PR DESCRIPTION
The VSCode MCP integration sends for completion requests also empty values resulting in an error s.

<img width="804" height="105" alt="image" src="https://github.com/user-attachments/assets/1875f338-a048-4f07-b6ad-e29d74c0ee73" />

This PR removes the empty check to allow empty values for the completion argument.

