### PR TITLE
make properties protected to avoid PHP deprecation errors

### DIFF
--- a/src/Shared/BaseSession.php
+++ b/src/Shared/BaseSession.php
@@ -54,11 +54,11 @@ use RuntimeException;
 abstract class BaseSession {
     protected bool $isInitialized = false;
     /** @var array<int, callable(JsonRpcMessage):void> */
-    private array $responseHandlers = [];
+    protected array $responseHandlers = [];
     /** @var callable[] */
-    private array $requestHandlers = [];
+    protected array $requestHandlers = [];
     /** @var callable[] */
-    private array $notificationHandlers = [];
+    protected array $notificationHandlers = [];
     private int $requestId = 0;
 
     /**


### PR DESCRIPTION
This fixes #46 

In PHP8 you will get a deprecation warning if you create non-existent properties on an object, resulting in errors like: "Creation of dynamic property Mcp\Server\ServerSession::$requestHandlers is deprecated"

The properties were defined in the base class, but are private. They should be protected to avoid the deprecation warning in the inherited classes.