### PR TITLE
Fix server session handler registration

### DIFF
--- a/src/Server/ServerSession.php
+++ b/src/Server/ServerSession.php
@@ -63,6 +63,10 @@ class ServerSession extends BaseSession {
     protected ?InitializeRequestParams $clientParams = null;
     protected LoggerInterface $logger;
     protected string $negotiatedProtocolVersion = Version::LATEST_PROTOCOL_VERSION;
+    /** @var array<string, callable> */
+    private array $requestMethodHandlers = [];
+    /** @var array<string, callable> */
+    private array $notificationMethodHandlers = [];
 
     public function __construct(
         protected readonly Transport $transport,
@@ -147,13 +151,13 @@ class ServerSession extends BaseSession {
 
     public function registerHandlers(array $handlers): void {
         foreach ($handlers as $method => $callable) {
-            $this->requestHandlers[$method] = $callable;
+            $this->requestMethodHandlers[$method] = $callable;
         }
     }
 
     public function registerNotificationHandlers(array $handlers): void {
         foreach ($handlers as $method => $callable) {
-            $this->notificationHandlers[$method] = $callable;
+            $this->notificationMethodHandlers[$method] = $callable;
         }
     }
 
@@ -169,6 +173,15 @@ class ServerSession extends BaseSession {
         $actualRequest = $request->getRequest(); // the underlying typed Request
         $method = $actualRequest->method;
         $params = $actualRequest->params ?? [];
+        if ($params instanceof \Mcp\Types\McpModel) {
+            $serialized = $params->jsonSerialize();
+            if ($serialized instanceof \stdClass) {
+                $serialized = (array) $serialized;
+            }
+            $params = (array) $serialized;
+        } elseif ($params instanceof \stdClass) {
+            $params = (array) $params;
+        }
 
         if ($method === 'initialize') {
             $respond = fn($result) => $responder->sendResponse($result);
@@ -181,14 +194,14 @@ class ServerSession extends BaseSession {
         }
 
         // Now we integrate the method-specific handlers:
-        if (isset($this->requestHandlers[$method])) {
+        if (isset($this->requestMethodHandlers[$method])) {
             $this->logger->info("Calling handler for method: $method");
-            $handler = $this->requestHandlers[$method];
+            $handler = $this->requestMethodHandlers[$method];
             try {
-            $result = $handler($params); // call the user-defined handler
-            $responder->sendResponse($result);
-            } catch(\Throwable $e) {
-            	$this->logger->info("Handler Error: $e");
+                $result = $handler($params); // call the user-defined handler
+                $responder->sendResponse($result);
+            } catch (\Throwable $e) {
+                $this->logger->error('Handler error for method ' . $method . ': ' . $e->getMessage());
             }
         } else {
             $this->logger->info("No registered handler for method: $method");
@@ -216,6 +229,29 @@ class ServerSession extends BaseSession {
 
         if ($this->initializationState !== InitializationState::Initialized) {
             throw new RuntimeException('Received notification before initialization was complete');
+        }
+
+        if (isset($this->notificationMethodHandlers[$method])) {
+            $handler = $this->notificationMethodHandlers[$method];
+            try {
+                $params = $actualNotification->params ?? null;
+                if ($params instanceof \Mcp\Types\McpModel) {
+                    $serialized = $params->jsonSerialize();
+                    if ($serialized instanceof \stdClass) {
+                        $serialized = (array) $serialized;
+                    }
+                    $params = (array) $serialized;
+                } elseif ($params instanceof \stdClass) {
+                    $params = (array) $params;
+                }
+                if ($params === null) {
+                    $params = [];
+                }
+                $handler($params);
+            } catch (\Throwable $e) {
+                $this->logger->error('Notification handler error: ' . $e->getMessage());
+            }
+            return;
         }
 
         // Fallback for notifications you haven't specialized:


### PR DESCRIPTION
## Summary
- maintain separate registries for method request and notification handlers so the base session callbacks remain intact
- normalize handler parameters before invocation and improve error logging for request and notification handlers

## Testing
- php -l src/Server/ServerSession.php

------
https://chatgpt.com/codex/tasks/task_e_690076e5dae4832fb3d871bbff55168c