### PR TITLE
Fix notification parameter inheritance

### DIFF
--- a/src/Types/LoggingMessageNotificationParams.php
+++ b/src/Types/LoggingMessageNotificationParams.php
@@ -36,16 +36,21 @@ namespace Mcp\Types;
  *   data: unknown;
  * }
  */
-class LoggingMessageNotificationParams implements McpModel {
+class LoggingMessageNotificationParams extends NotificationParams {
     use ExtraFieldsTrait;
 
     public function __construct(
         public readonly LoggingLevel $level,
         public readonly mixed $data,
         public ?string $logger = null,
-    ) {}
+        ?Meta $_meta = null,
+    ) {
+        parent::__construct($_meta);
+    }
 
     public function validate(): void {
+        parent::validate();
+
         if ($this->data === null) {
             throw new \InvalidArgumentException('Logging message data cannot be null');
         }
@@ -59,6 +64,13 @@ class LoggingMessageNotificationParams implements McpModel {
         if ($this->logger !== null) {
             $data['logger'] = $this->logger;
         }
-        return array_merge($data, $this->extraFields);
+        $parentData = parent::jsonSerialize();
+        if ($parentData instanceof \stdClass) {
+            $parentData = (array) $parentData;
+        }
+
+        $merged = array_merge($parentData, $data, $this->extraFields);
+
+        return !empty($merged) ? $merged : new \stdClass();
     }
 }

--- a/src/Types/ProgressNotificationParams.php
+++ b/src/Types/ProgressNotificationParams.php
@@ -36,17 +36,22 @@ namespace Mcp\Types;
  *   total?: number
  * }
  */
-class ProgressNotificationParams implements McpModel {
+class ProgressNotificationParams extends NotificationParams {
     use ExtraFieldsTrait;
 
     public function __construct(
         public readonly ProgressToken $progressToken,
         public readonly float $progress,
         public ?float $total = null,
-        public ?string $message = null
-    ) {}
+        public ?string $message = null,
+        ?Meta $_meta = null,
+    ) {
+        parent::__construct($_meta);
+    }
 
     public function validate(): void {
+        parent::validate();
+
         $this->progressToken->validate();
         if ($this->total !== null && $this->total < $this->progress) {
             throw new \InvalidArgumentException('Total progress cannot be less than current progress');
@@ -64,6 +69,13 @@ class ProgressNotificationParams implements McpModel {
         if ($this->message !== null) {
             $data['message'] = $this->message;
         }
-        return array_merge($data, $this->extraFields);
+        $parentData = parent::jsonSerialize();
+        if ($parentData instanceof \stdClass) {
+            $parentData = (array) $parentData;
+        }
+
+        $merged = array_merge($parentData, $data, $this->extraFields);
+
+        return !empty($merged) ? $merged : new \stdClass();
     }
 }

--- a/src/Types/ResourceUpdatedNotificationParams.php
+++ b/src/Types/ResourceUpdatedNotificationParams.php
@@ -32,20 +32,34 @@ namespace Mcp\Types;
  * Params for ResourceUpdatedNotification:
  * { uri: string }
  */
-class ResourceUpdatedNotificationParams implements McpModel {
+class ResourceUpdatedNotificationParams extends NotificationParams {
     use ExtraFieldsTrait;
 
     public function __construct(
-        public readonly string $uri
-    ) {}
+        public readonly string $uri,
+        ?Meta $_meta = null,
+    ) {
+        parent::__construct($_meta);
+    }
 
     public function validate(): void {
+        parent::validate();
+
         if (empty($this->uri)) {
             throw new \InvalidArgumentException('Resource URI cannot be empty');
         }
     }
 
     public function jsonSerialize(): mixed {
-        return array_merge(['uri' => $this->uri], $this->extraFields);
+        $data = ['uri' => $this->uri];
+
+        $parentData = parent::jsonSerialize();
+        if ($parentData instanceof \stdClass) {
+            $parentData = (array) $parentData;
+        }
+
+        $merged = array_merge($parentData, $data, $this->extraFields);
+
+        return !empty($merged) ? $merged : new \stdClass();
     }
 }


### PR DESCRIPTION
## Summary
- update logging, progress, and resource-updated notification parameter models to extend NotificationParams
- ensure notification parameter models validate and serialize parent metadata alongside custom fields

## Testing
- composer install *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_690ac4702558832fac68d21bf03c85fe