### PR TITLE
Allow custom MCP server version configuration

### DIFF
--- a/src/Server/McpServer.php
+++ b/src/Server/McpServer.php
@@ -131,11 +131,16 @@ class McpServer
      *
      * @param string $name The server name advertised during initialization
      * @param LoggerInterface|null $logger [Added] Optional PSR-3 logger
+     * @param string $version The server version advertised during initialization
      */
-    public function __construct(string $name, ?LoggerInterface $logger = null)
+    public function __construct(
+        string $name,
+        ?LoggerInterface $logger = null,
+        string $version = '1.0.0',
+    )
     {
         $this->logger = $logger ?? new NullLogger();
-        $this->server = new Server($name, $this->logger);
+        $this->server = new Server($name, $this->logger, $version);
         $this->registerDefaultHandlers();
     }
 

--- a/src/Server/Server.php
+++ b/src/Server/Server.php
@@ -69,7 +69,8 @@ class Server {
 
     public function __construct(
         private readonly string $name,
-        ?LoggerInterface $logger = null
+        ?LoggerInterface $logger = null,
+        private readonly string $version = '1.0.0',
     ) {
         $this->logger = $logger ?? new NullLogger();
         $this->logger->debug("Initializing server '$name'");
@@ -95,7 +96,7 @@ class Server {
 
         return new InitializationOptions(
             serverName: $this->name,
-            serverVersion: $this->getPackageVersion('mcp'),
+            serverVersion: $this->version,
             capabilities: $this->getCapabilities($notificationOptions, $experimentalCapabilities)
         );
     }
@@ -306,17 +307,6 @@ class Server {
         }
 
         $this->session->sendResponse($id, $error);
-    }
-
-    /**
-     * Retrieves the package version.
-     *
-     * @param string $package The package name.
-     * @return string The package version.
-     */
-    private function getPackageVersion(string $package): string {
-        // Return a static version. Actual implementation can read from composer.json or elsewhere.
-        return '1.0.0';
     }
 
     /**


### PR DESCRIPTION
This PR introduces support for configuring a custom MCP server version string, which is advertised to clients during the initialization handshake.

---

### ✨ Changes

#### 1. Server version is now configurable

* `Server::__construct()` now accepts an optional `string $version` parameter (default: `'1.0.0'`)
* The version is now directly used in `InitializationOptions`
* The previously hardcoded `getPackageVersion()` method has been removed

---

#### 2. Propagation through higher-level API

* `McpServer::__construct()` now exposes the same optional `$version` parameter
* The value is forwarded to the underlying `Server` instance

---

### 🧪 Usage

#### High-level API

```php id="mcp_high_level"
$server = new McpServer('my-server', version: '2.3.1');
```

#### Low-level API

```php id="mcp_low_level"
$server = new Server('my-server', version: '2.3.1');
```

---

### 🔄 Before

The server version was always hardcoded to:

```
1.0.0
```

via a private `getPackageVersion()` stub, with no ability to override it.

---

### 🚀 After

The server version can now be explicitly defined by the user:

* Improves flexibility for deployments
* Allows proper semantic versioning per application
* Aligns server metadata with real release versions

---

### 🎯 Motivation

This change improves observability and interoperability by ensuring the MCP server can accurately report its actual version to clients, instead of relying on a static hardcoded value.

---

### ⚠️ Backward compatibility

* Fully backward compatible
* Default version remains `1.0.0`

---

Happy to adjust if you want a more strict “RFC-style” or more minimal PR format.
