### PR TITLE
Prevent stdio server EOF hang. Fixes #61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,26 @@ This file was introduced during the v1.7.x series. Structured entries below cove
 **v1.6.0 and later**; earlier releases can be reviewed via the
 [Git tag history](https://github.com/logiscape/mcp-sdk-php/tags).
 
+## [1.7.4]
+
+### Fixed
+
+- The stdio server now detects EOF on stdin and shuts down cleanly instead
+  of busy-waiting forever
+  ([#61](https://github.com/logiscape/mcp-sdk-php/issues/61)). Per the MCP
+  lifecycle, a client initiates stdio shutdown by closing the server's
+  stdin and waiting for the process to exit; previously
+  `StdioServerTransport::readMessage()` treated EOF as "no data yet",
+  leaving the process spinning in a 10 ms sleep loop until the client
+  escalated to `SIGTERM` — which never arrives in some Docker setups,
+  orphaning the process. `readMessage()` now throws the new
+  `Mcp\Server\Transport\TransportClosedException` at EOF, which
+  `ServerSession` treats as a clean shutdown signal (the message loop exits
+  and the session stops). Handler-wrapping catch blocks in `ServerSession`
+  and `McpServer` rethrow it so a tool blocked on a stdio
+  elicitation/sampling round-trip cannot swallow the shutdown into an
+  error response aimed at a dead stream.
+
 ## [1.7.3]
 
 ### Added

--- a/src/Server/McpServer.php
+++ b/src/Server/McpServer.php
@@ -32,6 +32,7 @@ use Mcp\Server\Transport\Http\FileSessionStore;
 use Mcp\Server\Transport\Http\HttpIoInterface;
 use Mcp\Server\Transport\Http\SessionStoreInterface;
 use Mcp\Server\Transport\Http\StandardPhpAdapter;
+use Mcp\Server\Transport\TransportClosedException;
 use Mcp\Types\BlobResourceContents;
 use Mcp\Types\CallToolResult;
 use Mcp\Types\CompleteResult;
@@ -965,6 +966,12 @@ class McpServer
                 $result = $handler($arguments, $meta);
             } catch (ClientRequestSuspendException $e) {
                 throw $e; // Must propagate to HttpServerSession for suspend/resume
+            } catch (TransportClosedException $e) {
+                // Client disconnected while the tool was blocked on a client
+                // round-trip (stdio elicitation/sampling): never convert the
+                // shutdown signal into an isError result — propagate so the
+                // session's message loop can exit.
+                throw $e;
             } catch (McpServerException $e) {
                 throw $e; // Programming errors should propagate
             } catch (\Throwable $e) {

--- a/src/Server/ServerSession.php
+++ b/src/Server/ServerSession.php
@@ -67,6 +67,7 @@ use Mcp\Types\SamplingMessage;
 use Mcp\Types\TaskRequestParams;
 use Mcp\Types\ToolChoice;
 use Mcp\Server\Transport\Transport;
+use Mcp\Server\Transport\TransportClosedException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
@@ -234,6 +235,12 @@ class ServerSession extends BaseSession {
             try {
                 $result = $handler($params); // call the user-defined handler
                 $responder->sendResponse($result);
+            } catch (TransportClosedException $e) {
+                // The client disconnected while the handler was blocked on a
+                // client round-trip (stdio elicitation/sampling). Writing an
+                // error response to the dead stream is pointless — propagate
+                // so startMessageProcessing() can shut the session down.
+                throw $e;
             } catch (\Mcp\Shared\McpError $e) {
                 $this->logger->error("Handler error for method '$method': " . $e->getMessage());
                 $responder->sendResponse($e->error);
@@ -886,8 +893,19 @@ class ServerSession extends BaseSession {
         // This could be a loop or a separate thread in a real implementation
         // For demonstration, we'll use a simple loop
         while ($this->isInitialized) {
-            $message = $this->readNextMessage();
-            $this->handleIncomingMessage($message);
+            try {
+                $message = $this->readNextMessage();
+                $this->handleIncomingMessage($message);
+            } catch (TransportClosedException $e) {
+                // The client closed our stdin — the spec's stdio shutdown
+                // signal. stop() (idempotent, so ServerRunner's own stop()
+                // in its finally block stays a no-op) stops the transport
+                // and resets the initialized flag so the process can exit
+                // cleanly.
+                $this->logger->info('Client closed the connection; shutting down: ' . $e->getMessage());
+                $this->stop();
+                return;
+            }
         }
     }
 

--- a/src/Server/Transport/StdioServerTransport.php
+++ b/src/Server/Transport/StdioServerTransport.php
@@ -138,8 +138,10 @@ class StdioServerTransport implements Transport {
      *
      * @return JsonRpcMessage|null
      *   Returns a JsonRpcMessage if successfully parsed,
-     *   or null if no data is available.
+     *   or null if no data is available yet.
      * @throws RuntimeException if transport not started
+     * @throws TransportClosedException if stdin has reached EOF (the client
+     *         closed the stream to initiate shutdown per the MCP lifecycle)
      * @throws McpError on JSON parsing or validation error
      */
     public function readMessage(): ?JsonRpcMessage {
@@ -149,7 +151,16 @@ class StdioServerTransport implements Transport {
 
         $line = fgets($this->stdin);
         if ($line === false) {
-            // No data to read
+            // fgets() returns false both when a non-blocking stream has no
+            // data yet and at EOF; only feof() tells them apart. EOF means
+            // the client closed our stdin — the spec's stdio shutdown
+            // signal — so no message can ever arrive again.
+            if (feof($this->stdin)) {
+                throw new TransportClosedException(
+                    'stdin closed (EOF) — client disconnected'
+                );
+            }
+            // No data to read yet
             return null;
         }
 

--- a/src/Server/Transport/TransportClosedException.php
+++ b/src/Server/Transport/TransportClosedException.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Model Context Protocol SDK for PHP
+ *
+ * (c) 2024 Logiscape LLC <https://logiscape.com>
+ *
+ * Based on the Python SDK for the Model Context Protocol
+ * https://github.com/modelcontextprotocol/python-sdk
+ *
+ * PHP conversion developed by:
+ * - Josh Abbott
+ * - Claude 3.5 Sonnet (Anthropic AI model)
+ * - ChatGPT o1 pro mode
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package    logiscape/mcp-sdk-php
+ * @author     Josh Abbott <https://joshabbott.com>
+ * @copyright  Logiscape LLC
+ * @license    MIT License
+ * @link       https://github.com/logiscape/mcp-sdk-php
+ *
+ * Filename: Server/Transport/TransportClosedException.php
+ */
+
+declare(strict_types=1);
+
+namespace Mcp\Server\Transport;
+
+use RuntimeException;
+
+/**
+ * Thrown when the peer has closed the transport's incoming channel and no
+ * further messages can ever arrive — for the stdio transport, EOF on STDIN,
+ * which is how an MCP client initiates shutdown per the spec's lifecycle
+ * rules (close stdin first, then wait for the server process to exit).
+ *
+ * ServerSession treats this as a clean shutdown signal: the message loop
+ * stops and the session is closed, allowing the server process to terminate
+ * instead of busy-waiting on a dead stream. Code that catches \Throwable
+ * around handler execution must rethrow this exception so it can reach the
+ * message loop.
+ */
+class TransportClosedException extends RuntimeException
+{
+}

--- a/tests/Server/ServerSessionStdinEofTest.php
+++ b/tests/Server/ServerSessionStdinEofTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mcp\Tests\Server;
+
+use Mcp\Server\InitializationOptions;
+use Mcp\Server\ServerSession;
+use Mcp\Server\Transport\Transport;
+use Mcp\Server\Transport\TransportClosedException;
+use Mcp\Shared\Version;
+use Mcp\Types\JsonRpcMessage;
+use Mcp\Types\JSONRPCError;
+use Mcp\Types\JSONRPCNotification;
+use Mcp\Types\JSONRPCRequest;
+use Mcp\Types\JSONRPCResponse;
+use Mcp\Types\RequestId;
+use Mcp\Types\RequestParams;
+use Mcp\Types\Result;
+use Mcp\Types\ServerCapabilities;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for GitHub issue #61 at the session level: when the
+ * transport reports that the client closed the connection
+ * (TransportClosedException — stdio EOF), ServerSession::start()'s message
+ * loop must terminate and stop the session, instead of spinning forever.
+ * Before the fix these tests would hang: the stdio transport returned null
+ * at EOF and readNextMessage() usleep-looped on null indefinitely.
+ */
+final class ServerSessionStdinEofTest extends TestCase
+{
+    /**
+     * Main-loop shutdown: after the handshake, EOF must make start() return
+     * with the session fully stopped (isInitialized() false — a bare loop
+     * exit would leave direct ServerSession users in an initialized state),
+     * having written nothing beyond the initialize response.
+     */
+    public function testStartReturnsAndStopsSessionOnEof(): void
+    {
+        $transport = new StdinEofTransport();
+        $session = $this->buildSession($transport);
+
+        $transport->enqueue($this->initializeRequest());
+        $transport->enqueue($this->initializedNotification());
+
+        $session->start();
+
+        $this->assertFalse($session->isInitialized(), 'EOF shutdown must close the session, not just exit the loop');
+        $this->assertCount(1, $transport->written, 'only the initialize response should have been written');
+        $this->assertInstanceOf(JSONRPCResponse::class, $transport->written[0]->message);
+    }
+
+    /**
+     * Mid-handler shutdown: a request handler blocked in a client round-trip
+     * (stdio elicitation) sees TransportClosedException surface from its
+     * blocking read. The generic handler catches must rethrow it — EOF may
+     * not be converted into a -32603 error response aimed at the dead
+     * stream — and the session must still shut down cleanly.
+     */
+    public function testEofInsideBlockingHandlerIsNotSwallowedIntoErrorResponse(): void
+    {
+        $transport = new StdinEofTransport();
+        // 'tools/call' rather than an invented method: session intake
+        // constructs typed requests and answers unknown methods -32601
+        // before they can reach a registered handler.
+        $session = $this->buildSession($transport, [
+            'tools/call' => function () use (&$session): Result {
+                // Blocks in waitForResponse() → readNextMessage(); the queue
+                // is drained, so the next transport read reports EOF.
+                return $session->sendElicitationRequest(
+                    message: 'What is your name?',
+                    requestedSchema: [
+                        'type' => 'object',
+                        'properties' => ['name' => ['type' => 'string']],
+                        'required' => ['name'],
+                    ],
+                );
+            },
+        ]);
+
+        $transport->enqueue($this->initializeRequest());
+        $transport->enqueue($this->initializedNotification());
+        $params = new RequestParams();
+        $params->name = 'blocking-tool';
+        $params->arguments = [];
+        $transport->enqueue(new JsonRpcMessage(new JSONRPCRequest(
+            jsonrpc: '2.0',
+            id: new RequestId(2),
+            method: 'tools/call',
+            params: $params,
+        )));
+
+        $session->start();
+
+        $this->assertFalse($session->isInitialized());
+        // Written: the initialize response, then the outgoing
+        // elicitation/create request — and nothing after EOF.
+        $this->assertCount(2, $transport->written, 'no response may be written for the request interrupted by EOF');
+        $this->assertInstanceOf(JSONRPCRequest::class, $transport->written[1]->message);
+        $this->assertSame('elicitation/create', $transport->written[1]->message->method);
+        foreach ($transport->written as $message) {
+            $this->assertNotInstanceOf(
+                JSONRPCError::class,
+                $message->message,
+                'EOF must never be converted into a JSON-RPC error response'
+            );
+        }
+    }
+
+    /**
+     * @param array<string, callable> $handlers
+     */
+    private function buildSession(StdinEofTransport $transport, array $handlers = []): ServerSession
+    {
+        $session = new ServerSession(
+            $transport,
+            new InitializationOptions(
+                serverName: 'stdin-eof-test',
+                serverVersion: '1.0.0',
+                capabilities: new ServerCapabilities(),
+            ),
+        );
+        $session->registerHandlers($handlers);
+        $session->registerNotificationHandlers([]);
+
+        return $session;
+    }
+
+    private function initializeRequest(): JsonRpcMessage
+    {
+        return new JsonRpcMessage(new JSONRPCRequest(
+            jsonrpc: '2.0',
+            id: new RequestId(1),
+            method: 'initialize',
+            params: new RawInitializeParamsForEofTest(
+                protocolVersion: Version::LATEST_PROTOCOL_VERSION,
+                capabilities: ['elicitation' => []],
+                clientInfo: ['name' => 'test-client', 'version' => '1.0.0'],
+            ),
+        ));
+    }
+
+    private function initializedNotification(): JsonRpcMessage
+    {
+        return new JsonRpcMessage(new JSONRPCNotification(
+            jsonrpc: '2.0',
+            method: 'notifications/initialized',
+            params: null,
+        ));
+    }
+}
+
+/**
+ * Queue-backed transport that reports a closed connection (stdio EOF) once
+ * its queue is drained — the post-fix StdioServerTransport contract — and
+ * captures every write for assertions.
+ */
+final class StdinEofTransport implements Transport
+{
+    /** @var JsonRpcMessage[] */
+    public array $written = [];
+
+    /** @var JsonRpcMessage[] */
+    private array $incoming = [];
+
+    public function enqueue(JsonRpcMessage $message): void
+    {
+        $this->incoming[] = $message;
+    }
+
+    public function start(): void {}
+    public function stop(): void {}
+
+    public function readMessage(): ?JsonRpcMessage
+    {
+        $message = array_shift($this->incoming);
+        if ($message === null) {
+            throw new TransportClosedException('stdin closed (EOF) — client disconnected');
+        }
+        return $message;
+    }
+
+    public function writeMessage(JsonRpcMessage $message): void
+    {
+        $this->written[] = $message;
+    }
+}
+
+/**
+ * Raw initialize params that serialize to wire-format arrays, declaring the
+ * elicitation capability so sendElicitationRequest() is allowed.
+ */
+final class RawInitializeParamsForEofTest extends RequestParams
+{
+    /**
+     * @param array<string, mixed> $capabilities
+     * @param array<string, string> $clientInfo
+     */
+    public function __construct(
+        private readonly string $protocolVersion,
+        private readonly array $capabilities,
+        private readonly array $clientInfo,
+    ) {
+        parent::__construct();
+    }
+
+    public function validate(): void {}
+
+    public function jsonSerialize(): mixed
+    {
+        return [
+            'protocolVersion' => $this->protocolVersion,
+            'capabilities' => $this->capabilities,
+            'clientInfo' => $this->clientInfo,
+        ];
+    }
+}

--- a/tests/Server/Transport/StdioServerTransportEofTest.php
+++ b/tests/Server/Transport/StdioServerTransportEofTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mcp\Tests\Server\Transport;
+
+use Mcp\Server\Transport\StdioServerTransport;
+use Mcp\Server\Transport\TransportClosedException;
+use Mcp\Types\JsonRpcMessage;
+use Mcp\Types\JSONRPCRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for GitHub issue #61: StdioServerTransport treated EOF on
+ * stdin as "no data yet" and returned null forever, so a server whose client
+ * had closed stdin (the MCP lifecycle's stdio shutdown signal) never left its
+ * message loop — the process spun in a 10 ms sleep loop until an external
+ * SIGTERM, which some Docker setups never deliver.
+ *
+ * The contract pinned here: readMessage() returns null only while the stream
+ * is still open with no complete line available, and throws
+ * TransportClosedException once stdin reaches EOF.
+ */
+final class StdioServerTransportEofTest extends TestCase
+{
+    /**
+     * A stream that is already at EOF (empty, nothing will ever arrive) must
+     * surface as TransportClosedException, not as an endless null.
+     */
+    public function testReadMessageThrowsAtImmediateEof(): void
+    {
+        $stdin = fopen('php://memory', 'r+');
+        $stdout = fopen('php://memory', 'r+');
+        $this->assertIsResource($stdin);
+        $this->assertIsResource($stdout);
+
+        $transport = new StdioServerTransport($stdin, $stdout);
+        $transport->start();
+
+        $this->expectException(TransportClosedException::class);
+        $transport->readMessage();
+    }
+
+    /**
+     * Buffered data is still delivered before the EOF signal: one valid
+     * message parses normally, and only the read after it throws.
+     */
+    public function testReadMessageDeliversBufferedMessageThenThrows(): void
+    {
+        $stdin = fopen('php://memory', 'r+');
+        $stdout = fopen('php://memory', 'r+');
+        $this->assertIsResource($stdin);
+        $this->assertIsResource($stdout);
+
+        fwrite($stdin, '{"jsonrpc":"2.0","id":1,"method":"ping"}' . "\n");
+        rewind($stdin);
+
+        $transport = new StdioServerTransport($stdin, $stdout);
+        $transport->start();
+
+        $message = $transport->readMessage();
+        $this->assertInstanceOf(JsonRpcMessage::class, $message);
+        $this->assertInstanceOf(JSONRPCRequest::class, $message->message);
+        $this->assertSame('ping', $message->message->method);
+
+        $this->expectException(TransportClosedException::class);
+        $transport->readMessage();
+    }
+
+    /**
+     * The distinction the fix hinges on: a non-blocking stream with no data
+     * available yet is NOT EOF — readMessage() must keep returning null so
+     * the session keeps polling — while the peer closing its end must turn
+     * the very same call into TransportClosedException.
+     */
+    public function testIdleOpenStreamReturnsNullUntilPeerCloses(): void
+    {
+        $domain = PHP_OS_FAMILY === 'Windows' ? STREAM_PF_INET : STREAM_PF_UNIX;
+        $pair = @stream_socket_pair($domain, STREAM_SOCK_STREAM, $domain === STREAM_PF_INET ? STREAM_IPPROTO_IP : 0);
+        if ($pair === false) {
+            $this->markTestSkipped('stream_socket_pair() is unavailable on this platform');
+        }
+        [$readEnd, $writeEnd] = $pair;
+        $stdout = fopen('php://memory', 'r+');
+        $this->assertIsResource($stdout);
+
+        $transport = new StdioServerTransport($readEnd, $stdout);
+        $transport->start();
+        // start() only switches to non-blocking mode on non-Windows; force it
+        // here so the test exercises the same configuration on every platform
+        // (and never blocks in fgets on an idle socket).
+        $this->assertTrue(stream_set_blocking($readEnd, false));
+
+        $this->assertNull($transport->readMessage(), 'idle open stream must read as "no data yet"');
+        $this->assertNull($transport->readMessage(), 'still no data: must stay null, not EOF');
+
+        fwrite($writeEnd, '{"jsonrpc":"2.0","id":2,"method":"ping"}' . "\n");
+        $message = $this->readUntilAvailable($transport);
+        $this->assertInstanceOf(JSONRPCRequest::class, $message->message);
+
+        fclose($writeEnd);
+
+        $this->expectException(TransportClosedException::class);
+        // Socket delivery of the FIN may not be instantaneous; poll through
+        // the transient nulls until the transport reports the closed stream.
+        for ($i = 0; $i < 100; $i++) {
+            if ($transport->readMessage() === null) {
+                usleep(10000);
+            }
+        }
+        $this->fail('readMessage() never signalled EOF after the peer closed the stream');
+    }
+
+    /**
+     * Drain transient nulls from a non-blocking socket until the just-written
+     * message becomes readable.
+     */
+    private function readUntilAvailable(StdioServerTransport $transport): JsonRpcMessage
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $message = $transport->readMessage();
+            if ($message !== null) {
+                return $message;
+            }
+            usleep(10000);
+        }
+        $this->fail('message written to the socket pair never became readable');
+    }
+}


### PR DESCRIPTION
(cherry picked from commit 7e4300c408ef9701a586f10f00384b0401ae395f)

<!--
Thanks for contributing. Please fill in the sections below — they help
reviewers land your PR faster. See CONTRIBUTING.md for the guiding principles
and testing expectations.
-->

## Summary

<!-- What does this PR do, in one or two sentences? -->

## Motivation

<!-- Why is this change needed? Link any relevant issue(s) with "Fixes #123" or "Refs #456". -->

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Minor feature or improvement (non-breaking, additive)
- [ ] Major feature (non-breaking but substantial — requires a minor version bump)
- [ ] Expanded MCP protocol version support (adopting a new spec revision — requires a minor version bump)
- [ ] Breaking change (public API or documented flow — requires a minor version bump)
- [ ] Documentation only
- [ ] Tooling / CI only

## Versioning impact

<!-- See the semver policy in CONTRIBUTING.md. -->

- [X] Patch (`v1.7.X`) — non-breaking bug fix or minor feature/improvement
- [ ] Minor (`v1.X`) — breaking change, major new feature, or expanded MCP protocol version support
- [ ] Major (`v2`) — aligned with a wider MCP ecosystem `v2` (not chosen unilaterally)

If this is a breaking change, describe the break and the migration path here:

<!-- What used to work? What works now? How do users update their code? -->

## Test plan

Which layers did you run? (See [docs/testing.md](https://github.com/logiscape/mcp-sdk-php/blob/main/docs/testing.md).)

- [X] `composer check` passes locally
- [X] `composer conformance` passes locally (or documented baseline change included)
- [X] Relevant unit tests added or updated
- [ ] Spot-checked with the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) (for protocol-touching changes)
- [ ] Smoke-tested against a real MCP client (Claude Code, OpenAI API, or similar) — encouraged for user-visible changes

If you updated `conformance/conformance-baseline.yml`, explain why each entry
added or changed:

<!-- One or two sentences per entry. Remember the no-shortcut rule in conformance/README.md. -->

## Compatibility

- [ ] Change preserves core-feature compatibility under cPanel / Apache / PHP-FPM (see [docs/compatibility.md](https://github.com/logiscape/mcp-sdk-php/blob/main/docs/compatibility.md))
- [ ] If this introduces a feature that cannot work under shared hosting, it fails gracefully (typed exception, not a fatal error)
- [ ] No new required runtime dependencies (or new dependency justified in the PR)

## Documentation

- [ ] Updated `README.md` if the public API or usage changed
- [X] Added an entry to `CHANGELOG.md` under `[Unreleased]`
- [ ] Updated anything under `docs/` that this PR contradicts
- [ ] Updated `AGENTS.md` / `CLAUDE.md` if the contributor-facing guidance changed

## Additional notes

<!-- Anything reviewers should pay special attention to, or decisions you'd like confirmed. -->
